### PR TITLE
feat: use KBC_STORAGEAPI_URL to pass Storage API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ The following environment variables are used for configuration:
 - KBC_TOKEN - Storage API token.
 - KBC_DATADIR - Optional target directory, defaults to `/data/`
 - KBC_RUNID - Optional RunID, that appends to the log
+- KBC_STORAGEAPI_URL - Optional Storage API URL, if it's different from `https://connection.keboola.com`
 
 Run the loader with `php main.php`.

--- a/main.php
+++ b/main.php
@@ -19,7 +19,11 @@ try {
     if (empty($token)) {
         throw new InvalidInputException("Environment KBC_TOKEN is empty.");
     }
-    $client = new Client(['token' => $token]);
+    $options = ['token' => $token];
+    if (getenv('KBC_STORAGEAPI_URL')) {
+        $options['url'] = getenv('KBC_STORAGEAPI_URL');
+    }
+    $client = new Client($options);
 
     $runId = getenv('KBC_RUNID');
     if (empty($runId)) {


### PR DESCRIPTION
na testy zatím prdím? musel by se upravit sapi_client, aby uměl pracovat s jiným stackem