### PR TITLE
ingnore extra root level keys in V2 trans

### DIFF
--- a/src/TransformationV2Config.php
+++ b/src/TransformationV2Config.php
@@ -15,7 +15,7 @@ class TransformationV2Config implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $root = $treeBuilder->root('configuration');
-        $definition = $root->children()
+        $definition = $root->ignoreExtraKeys(false)->children()
             ->arrayNode('parameters')
                 ->addDefaultsIfNotSet()
                 ->ignoreExtraKeys(true)

--- a/tests/phpunit/TransformationV2ConfigTest.php
+++ b/tests/phpunit/TransformationV2ConfigTest.php
@@ -41,6 +41,32 @@ class TransformationV2ConfigTest extends TestCase
                     ],
                 ],
             ],
+            'extra stuff' => [
+                [
+                    'storage' => [],
+                    'parameters' => [],
+                    'variables_id' => '1234143',
+                    'variables_values_id' => '314123',
+                    'shared_code_id' => '23424553',
+                    'shared_code_row_ids' => ['6535334']
+                ],
+                [
+                    'storage' => [
+                        'input' => [
+                            'files' => [],
+                            'tables' => [],
+                        ],
+                    ],
+                    'parameters' => [
+                        'type' => 'python',
+                        'blocks' => [],
+                    ],
+                    'variables_id' => '1234143',
+                    'variables_values_id' => '314123',
+                    'shared_code_id' => '23424553',
+                    'shared_code_row_ids' => ['6535334']
+                ],
+            ],
             'full config' => [
                 [
                     'storage' => [


### PR DESCRIPTION
If there are top level variables or shared codes in the transformation configuration then it fails validation