### PR TITLE
fix: translate warnings to exceptions (PS-903)

### DIFF
--- a/src/run.php
+++ b/src/run.php
@@ -17,6 +17,17 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Symfony\Component\Filesystem\Filesystem;
 
+error_reporting(E_ALL);
+set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext): bool {
+    if (!(error_reporting() & $errno)) {
+        // respect error_reporting() level
+        // libraries used in custom components may emit notices that cannot be fixed
+        return false;
+    }
+
+    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+});
+
 $log = new Logger('app-logger');
 $log->pushHandler(new StreamHandler('php://stdout'));
 $log->info('Starting Data Loader');


### PR DESCRIPTION
I just copied-pasted it from php component: https://github.com/keboola/php-component/blob/master/src/BaseComponent.php#L70-L80